### PR TITLE
Minor tweaks to clear AMP error and support JS-free browsers

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,7 @@
 <head>
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,700|Lora:400,700' rel='stylesheet' type='text/css'>
   <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
+  <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
   {% comment %}
     <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
   {% endcomment %}

--- a/_posts/2018-10-06-A-Call-for-Contributors.md
+++ b/_posts/2018-10-06-A-Call-for-Contributors.md
@@ -53,6 +53,7 @@ We want you(!!!) to join us. If you can do anything involving:
 - pictures
 - baking cupcakes
 - having fun
+
 You're probably welcome! :) Please be excellent to each other.
 
 We share the Codes of Conduct with [Code&&Coffee](http://codeandcoffeelb.org/conduct/) and the [WordPress meetups](https://make.wordpress.org/community/handbook/meetup-organizer/resources/code-of-conduct/

--- a/_posts/2018-10-06-A-Call-for-Contributors.md
+++ b/_posts/2018-10-06-A-Call-for-Contributors.md
@@ -109,4 +109,6 @@ We're going to be goofy and use the technologies underpinning the websites we us
 ## I want to play along!
 To join, complete this form below or email us at info@averyseriouswebsite.net. 
 
-<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSeB7bh2nt5td0VubE3Xp4o3WJqw5kItvK-kCZT-5SY_L1IopQ/viewform?embedded=true" width="640" height="984" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
+<amp-iframe src="https://docs.google.com/forms/d/e/1FAIpQLSeB7bh2nt5td0VubE3Xp4o3WJqw5kItvK-kCZT-5SY_L1IopQ/viewform?embedded=true" width="640" height="984" frameborder="0">Loading...</amp-iframe>
+
+<noscript>Visit the form in a JS-enabled browser [here]( https://docs.google.com/forms/d/e/1FAIpQLSeB7bh2nt5td0VubE3Xp4o3WJqw5kItvK-kCZT-5SY_L1IopQ/viewform?embedded=true).</noscript>


### PR DESCRIPTION
@davidnuon - I found this wasn't validating correctly:
https://validator.ampproject.org/#url=https%3A%2F%2Fcodeis.software%2F2018%2F10%2F06%2FA-Call-for-Contributors.html

so I made a few tweaks. Also, for the future, we should probably come up with a way to conditionally load `amp` components for performance reasons, but this is good enough for today!